### PR TITLE
Feature twowayscatter addition 1

### DIFF
--- a/ados_to_install.do
+++ b/ados_to_install.do
@@ -1,3 +1,4 @@
+ssc install cdfplot
 ssc install coefplot
 ssc install estout
 ssc install eventstudy2

--- a/twowayscatter.ado
+++ b/twowayscatter.ado
@@ -3,7 +3,7 @@ version 14
 	syntax varlist(min=2 max=3) ///
 	 [ ,  color1(string) color2(string) conditions(string) ///
 		debug file(string) lfit ///
-	    type1(string) type2(string)]
+	    type1(string) type2(string) ncorr singleaxis]
 	
 	if "`type1'" == ""{
 		local type1 "scatter"
@@ -19,33 +19,41 @@ version 14
 	}
 		
 	token `varlist'
-	qui corr `1' `2' `conditions'
-	local corr : di  %5.3g r(rho)
 
 	if "`lfit'" == "lfit"{
 		local linegraph "(lfit `1' `2')"
+	}
+	
+	if "`ncorr'" != "ncorr" {
+		qui corr `1' `2' `conditions'
+		local corr : di  %5.3g r(rho)
+		local corrs "subtitle(correlation `corr')"
+	}
+	
+	if "`singleaxis'" != "singleaxis"{
+		local yaxisval "yaxis(2)"
 	}
 
 	if `k' == 3{
 		if "`color1'" != "" & "`color2'" != ""{
 		twoway (`type1' `1' `3' `conditions' , mcolor("`color1'")) ///
-			(`type2' `2' `3' `conditions' , yaxis(2) mcolor("`color2'")) `linegraph' , ///
-			graphregion(color(white)) subtitle("correlation `corr'")
+			(`type2' `2' `3' `conditions' , `yaxisval' mcolor("`color2'")) `linegraph' , ///
+			graphregion(color(white)) `corrs'
 		}
 		else {
 		twoway (`type1' `1' `3' `conditions') ///
-			(`type2' `2' `3' `conditions'  , yaxis(2)) `linegraph' , ///
-			graphregion(color(white)) subtitle("correlation `corr'") 
+			(`type2' `2' `3' `conditions'  , `yaxisval') `linegraph' , ///
+			graphregion(color(white)) `corrs'
 		}
 	}
 	else if `k' == 2{
 		if "`color1'" != "" {
 		twoway (`type1' `1' `2' `conditions' , mcolor("`color1'")) `linegraph' , ///
-			graphregion(color(white)) subtitle("correlation `corr'")
+			graphregion(color(white)) `corrs'
 		}
 		else {
 		twoway (`type1' `1' `2' `conditions') `linegraph' , ///
-			graphregion(color(white)) subtitle("correlation `corr'") 
+			graphregion(color(white)) `corrs'
 		}
 	}
 	

--- a/twowayscatter.sthlp
+++ b/twowayscatter.sthlp
@@ -4,12 +4,13 @@
 help for {hi:twowayscatter}
 {hline}
 
-{title:twowayscatter - A module to plot scatterplots and display the correlation.}
+{title:twowayscatter - A module to plot scatterplots and display a correlation.}
 
 {p 8 16 2}{cmd:twowayscatter} {cmdab:varlist(min=2, max=3)}
 [{cmd:,} 
 {cmdab:color1(}{it:string}{cmd:)} {cmdab:color2(}{it:string}{cmd:)} {cmdab:conditions(}{it:string}{cmd:)}
-debug {cmdab:file(}{it:string}{cmd:)} lfit {cmdab:type1(}{it:string}{cmd:)} {cmdab:type2(}{it:string}{cmd:)}]
+debug {cmdab:file(}{it:string}{cmd:)} lfit {cmdab:type1(}{it:string}{cmd:)} {cmdab:type2(}{it:string}{cmd:)} 
+ncorr singleaxis]
 
 {p 4 4 2}
 where
@@ -31,6 +32,12 @@ where
 
 {p 8 16 2}
 {it:type} optionally specifies the type of plot one wants. Default is scatterplot. Any graph type supported by {it:twoway} is valid.
+
+{p 8 16 2}
+{it:ncorr} Omitts correlation coefficient and legend.
+
+{p 8 16 2}
+{it:singleaxis} If three variables are specified, {it:singleaxis} plots both of them against the same y-axis.
 
 {title:Author}
 


### PR DESCRIPTION
Twowayscatter can now be given an option to not plot correlations, and to use a single axis for multiple variables.