### PR TITLE
init no longer sets type double by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can find the location of your `ado/personal` folder by typing `sysdir`. You 
 Seriously, we spent a lot of time coming with all those handy tricks
 
 ## Check out our examples
-We have written basic examples under `./example` that illustrate what you can do with `project` and the functionality that we support.
+We have written basic examples under `./examples/` that illustrate what you can do with `project` and the functionality that we support.
 
 ## Contributions are welcome
 Our base of ado files will improve the more people contribute to it. There are two ways to contribute:

--- a/init.ado
+++ b/init.ado
@@ -1,6 +1,5 @@
 program define init , rclass
-version 14
-	syntax [, debroute(string) debug hard omit proj(string) route(string)]
+	syntax [, debroute(string) debug double hard omit proj(string) route(string)]
 	clear all
 	discard
 	set more off
@@ -8,7 +7,9 @@ version 14
 	gl deb = "`debug'"
 	gl omit = "`omit'"
 	
-	set type double
+	if "`double'" == "double"{ 
+		set type double
+	}
 	
 	if ("$deb" == "debug" & "`proj'" != "") { // In debug mode change to route if specified
 		project `proj' , cd

--- a/init.sthlp
+++ b/init.sthlp
@@ -8,7 +8,7 @@ help for {hi:psave}
 
 {p 8 16 2}{cmd:init}
 {cmd:,} 
-[{cmdab:debroute(}{it:string}{cmd:)} {cmdab:debug} {cmdab:hard} {cmdab:omit}
+[{cmdab:debroute(}{it:string}{cmd:)} {cmdab:debug} {cmdab:double} {cmdab:hard} {cmdab:omit}
 {cmdab:proj(}{it:string}{cmd:)} {cmdab:route(}{it:string}{cmd:)}]
 
 {p 4 4 2}
@@ -20,6 +20,9 @@ where
 
 {p 8 16 2}
 {it:debug} adds {cmdab: global deb "debug"}.
+
+{p 8 16 2}
+{it:double} adds type double option to STATA.
 
 {p 8 16 2}
 {it:hard} clears all macros --including globals. {it:hard} overrides {it:debug}. 
@@ -39,7 +42,6 @@ This ado file does the following:
 clear all
 discard
 set more off
-set type double 
 
 {title:Author}
 


### PR DESCRIPTION
setting type double by default carries significant performance penalties. init no longer sets type double by default, but instead is left as an option.