### PR TITLE
Psave no randnone

### DIFF
--- a/psave.ado
+++ b/psave.ado
@@ -17,15 +17,10 @@ program define psave , rclass
 		} 
 	}
 	
-	if "`randnone'" != "randnone"{
-		// guarantees that the rows in the CSV are always ordered the same---
-		set seed 13237 // from random.org
-		
-		tempvar ordervar
-		gen `ordervar' = runiform()
-		sort `ordervar'
-		drop `ordervar'
-		// guarantees that the rows in the CSV are always ordered the same---
+	if "`randnone'" == "randnone"{
+		di "Option randnone has been deprecated."
+		di "psave does not shuffle data by default."
+		di "Consider omitting this argument."
 	}
 	
 	// compress to save information

--- a/psave.sthlp
+++ b/psave.sthlp
@@ -4,33 +4,29 @@
 help for {hi:psave}
 {hline}
 
-{title:psave - A module that saves to CSV, DTA and documents dependencies.}
+{title:psave} - A module that saves to CSV, DTA and documents dependencies.
 
 {p 8 16 2}{cmd:psave}
 {cmd:,} 
-{cmdab:file:(}{it:string}{cmd:)} [{cmdab:eopts:(}{it:string}{cmd:)} {cmdab:preserve} {cmdab:debug} 
-{cmdab:com} {cmdab:randnone} {cmdab:csvnone}]
+{cmdab:file:(}{it:string}{cmd:)} [{cmdab:com} {cmdab:csvnone} {cmdab:debug} {cmdab:eopts:(}{it:string}{cmd:)} {cmdab:preserve}]
 
 {p 4 4 2}
 where
+
+{p 8 16 2}
+{it:com} compresses the database to save space without losing precission. Regardless of user input {it:psave} will perform that operation if there are more than 1 million observations.
+
+{p 8 16 2}
+{it:csvnone} Don't store results in CSV format. If debug mode isn't specified will register DTA with project.
+
+{p 8 16 2}
+{it:debug} prevents psave from using {cmdab:project} functionality. In debug mode {it: psave} will not save a CSV file.
 
 {p 8 16 2}
 {it:eopts} refers to standard options of {cmdab:export delimited}.
 
 {p 8 16 2}
 {it:preserve} avoids clearing local memory.
-
-{p 8 16 2}
-{it:debug} prevents psave from using {cmdab:project} functionality. In debug mode {it: psave} will not save a CSV file.
-
-{p 8 16 2}
-{it:com} compresses the database to save space without losing precission. Regardless of user input {it:psave} will perform that operation if there are more than 1 million observations.
-
-{p 8 16 2}
-{it:randnone} By default {it:psave} stores data using a fixed seed. The user can turn off this functionality by specifying {it:randnone}, that forces {it:psave} to store data as is.
-
-{p 8 16 2}
-{it:csvnone} Don't store results in CSV format. If debug mode isn't specified will register DTA with project.
 
 {title:Authors}
 


### PR DESCRIPTION
Psave drops option randnone (psave does not shuffle data now). The reason for this is that even if we ordered rows according to the values of pseudo random numbers based on a constant seed, the order of rows still depended on the original ordering. Option randnone was in fact useless. 