### PR TITLE
solves bug with init

### DIFF
--- a/init.ado
+++ b/init.ado
@@ -1,6 +1,7 @@
 program define init , rclass
 	version 14
 	
+	// Check dependencies
 	capture findfile project.ado
 		if "`r(fn)'" == "" {
 		 di as txt "user-written package project needs to be installed first;"
@@ -16,22 +17,29 @@ program define init , rclass
 	}
 	
 	capture macro drop debug
+	
 	syntax [, debug debroute(string) double hard ignorefold logfile(string) omit proj(string) route(string)]
+	
+	// Clean session
 	clear all
 	discard
 	
+	// Check that user parameters are correct
 	if "`hard'" == "hard" & ("`debug'" == "debug" | "`omit'" == "omit"){
 		di "Cannot use option 'hard' with either 'debug' or 'omit'"
 		error 184
 	}
 	
+	// Define global debug and omit
 	gl deb = "`debug'"
 	gl omit = "`omit'"
 	
+	// Optionally set type double
 	if "`double'" == "double"{ 
 		set type double
 	}
 	
+	// Set working directory
 	if ("$deb" == "debug" & "`proj'" != "") { // In debug mode change to route if specified
 		project `proj' , cd
 		if "`debroute'" != ""{ // If debroute specified change WD with respect to root directory
@@ -40,21 +48,23 @@ program define init , rclass
 	}
 	else if "`route'" != "" & "$deb" == ""{
 			cd `route'
-		}
+	}
 	
 	// If log option set and not in debug mode open logile
 	if ("$deb" == "" & "`logfile'" != "") {
-		capture confirm file "./log/" //check if a log directory exists
-		// If directory exists, but wasn't specified by user, then store logfile there
+		cap log close
+		mata : st_numscalar("LogExists", direxists("./log/")) //check if a log directory exists
+		
 		local LogFolderSpecified = strpos("`logfile'", "log/") + strpos("`logfile'", "log\")
 		
-		if _rc == 0 & `LogFolderSpecified' == 0 & "`ignorefold'" == ""{ 
+		// If directory exists, but wasn't specified by user, then store logfile there
+		if LogExists == 1 & `LogFolderSpecified' == 0 & "`ignorefold'" == ""{ 
 			local logfile = "./log/" + "`logfile'"
 		}
-		cap log close
 		log using "`logfile'" , replace
 	}
 	
+	// Optionally drop all macros
 	if "`hard'" == "hard"{
 		macro drop _all
 	}


### PR DESCRIPTION
init was not storing logfiles in the correct folder by default. This isn't an issue with the code, but with a bug in STATA in Windows, I suspect. The previous code behaved as expected in Linux but failed to find the log folder in Windows. Solved by using Mata code.