### PR TITLE
Adds totalobs

### DIFF
--- a/totalobs.ado
+++ b/totalobs.ado
@@ -1,0 +1,10 @@
+program totalobs
+	syntax varlist [if]
+	
+	foreach var in `varlist' {
+	    qui su `var' `if'
+		local tots: di %13.0fc r(N)*r(mean)
+		di as error "Total observations: `tots'"
+		di as error "Figure excluding decimals."
+	}
+end

--- a/totalobs.sthlp
+++ b/totalobs.sthlp
@@ -1,0 +1,17 @@
+{smcl}
+{hline}
+help for {hi:totalobs}
+{hline}
+
+{title:totalobs} - A module that computes the total number of observations that meet a criteria.
+
+{p 8 16 2}{cmd:totalobs }{cmdab:varlist} [if]
+
+This is open source software distributed under the GPL-3 license. Ownership belongs to their respective authors.
+For more documentation, examples and the most up to date code visit {browse "https://github.com/economic-research/open-ado/"}
+This version is as at least as recent as commit: 5b2fd3bdd0f8451117fff480e2553f5b6a4bccb5
+
+{title:Author}
+
+{p 4} Jose A. Jurado {p_end}
+{p 4}jose.jurado.vadillo@gmail.com{p_end}


### PR DESCRIPTION
```totalobs``` is a simple utility that computes the total number of observations or the totals given a set of criteria.

For instance, it can calculate the total wages earned by Latino workers from the ACS microdata.